### PR TITLE
Simplify check-dist workflow

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build.  See status below:"
+          if ! diff --quiet --ignore-space-at-eol -- dist/; then
+            echo "Detected differences to the repository.  See status below:"
             git diff
             exit 1
           fi

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if ! diff --quiet --ignore-space-at-eol -- dist/; then
+          if ! git diff --quiet --ignore-space-at-eol -- dist/; then
             echo "Detected differences to the repository.  See status below:"
             git diff
             exit 1


### PR DESCRIPTION
`git diff` can control exit status.